### PR TITLE
Adds `wait-for-postgres.js` script

### DIFF
--- a/infra/compose.yaml
+++ b/infra/compose.yaml
@@ -1,5 +1,6 @@
 services:
   database:
+    container_name: "postgres-dev"
     image: "postgres:16.0-alpine3.18"
     env_file:
       - ../.env.development

--- a/infra/scripts/wait-for-postgres.js
+++ b/infra/scripts/wait-for-postgres.js
@@ -1,0 +1,18 @@
+const { exec } = require("node:child_process");
+
+function checkPostgres() {
+  exec("docker exec postgres-dev pg_isready --host localhost", handleReturn)
+
+  function handleReturn(error, stdout) {
+    if (stdout.search("accepting connections") === -1) {
+      process.stdout.write(".");
+      checkPostgres();
+      return;
+    }
+
+    console.log("\n🟢 PostgreSQL is ready and accepting connections!\n");
+  }
+}
+
+process.stdout.write("\n\n🔴 Waiting for PostgreSQL to be ready");
+checkPostgres();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "BJJTap is a platform for Brazilian Jiu-Jitsu (BJJ) enthusiasts, providing the latest news, tournament highlights, athlete interviews, and expert insights. Serving as a central hub, BJJTap fosters community engagement, connects practitioners, and offers a comprehensive resource for everything BJJ.",
   "main": "index.js",
   "scripts": {
-    "dev": "npm run services:up && next dev",
+    "dev": "npm run services:up && npm run wait-for-db && npm run migration:up && next dev",
     "services:up": "docker-compose -f infra/compose.yaml up -d",
     "services:stop": "docker-compose -f infra/compose.yaml stop",
     "services:down": "docker-compose -f infra/compose.yaml down",
@@ -14,7 +14,8 @@
     "test": "jest --runInBand",
     "test:watch": "jest --watchAll --runInBand",
     "migration:create": "node-pg-migrate -m infra/migrations create",
-    "migration:up": "node-pg-migrate -m infra/migrations --envPath .env.development up"
+    "migration:up": "node-pg-migrate -m infra/migrations --envPath .env.development up",
+    "wait-for-db": "node infra/scripts/wait-for-postgres.js"
   },
   "author": "Luiz Macedo",
   "license": "MIT",


### PR DESCRIPTION
This pull request includes several changes to improve the development environment setup and streamline the process of starting the application. The most important changes include adding a script to wait for PostgreSQL to be ready, updating the `compose.yaml` file to name the PostgreSQL container, and modifying the `package.json` scripts to integrate the new wait-for-db script.

Development environment setup improvements:

* [`infra/scripts/wait-for-postgres.js`](diffhunk://#diff-3091e13040aff55042712e4589b3d8d2b274dd97a1a33c5c838b7f2852edc66dR1-R18): Added a script to check if PostgreSQL is ready and accepting connections.
* [`infra/compose.yaml`](diffhunk://#diff-219e7374a844094f88cbc93d0b7ca0ad9bd6d99805ac8733fc4925e27f0cce11R3): Named the PostgreSQL container as `postgres-dev` to ensure consistent container identification.

`package.json` script updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7-R7): Updated the `dev` script to include the new `wait-for-db` script and run database migrations before starting the development server.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L17-R18): Added a new `wait-for-db` script to run the `wait-for-postgres.js` script.