### PR TITLE
Fix `orchestrator.js` bug

### DIFF
--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -17,7 +17,8 @@ async function waitForAllServices() {
       }
     }
   }
+}
 
-  export default {
-    waitForAllServices
-  };
+export default {
+  waitForAllServices
+};


### PR DESCRIPTION
This pull request includes a small change to the `tests/orchestrator.js` file. The change adds a closing brace to the `async function waitForAllServices()`. 

* [`tests/orchestrator.js`](diffhunk://#diff-a65fc2619561c7397298409867ff391834168dec7da7f57b036dabf150ccfde5R20): Added a closing brace to the `async function waitForAllServices()`.