### PR TITLE
Use the common ancestor between `base` and `head` to ensure only new commits in the PR are validated

### DIFF
--- a/.github/workflows/azure-static-web-apps-calm-glacier-00b08ae10.yml
+++ b/.github/workflows/azure-static-web-apps-calm-glacier-00b08ae10.yml
@@ -26,7 +26,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y docker-compose
       - run: npm ci
       - run: npm run lint:prettier:check
-      - run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+      - run: npx commitlint --from $(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}) --to ${{ github.event.pull_request.head.sha }} --verbose
       - run: npm test
 
       - name: Build And Deploy


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/azure-static-web-apps-calm-glacier-00b08ae10.yml` file to improve the commit linting process.

* [`.github/workflows/azure-static-web-apps-calm-glacier-00b08ae10.yml`](diffhunk://#diff-30c8b923f7ad012322dba1167f2a4ca0b553f59af306caccc6c21de9a5746a0dL29-R29): Updated the `commitlint` command to use `git merge-base` for determining the base commit, ensuring more accurate linting of commit messages.