### PR TITLE
Add initial version of `/status` page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - React - Frontend
 - react-dom - React DOM
 - Next.js - React framework
+- SWR - React hooks library for data fetching
 - Node.js - Javascript runtime
 - PostgreSQL - Database
 - pg - PostgreSQL client for Node.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "bjjtap",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "UNLICENSED",
       "dependencies": {
         "async-retry": "1.3.3",
         "dotenv": "16.4.7",
@@ -16,7 +16,8 @@
         "node-pg-migrate": "7.8.0",
         "pg": "8.13.1",
         "react": "19.0.0",
-        "react-dom": "19.0.0"
+        "react-dom": "19.0.0",
+        "swr": "^2.3.0"
       },
       "devDependencies": {
         "@commitlint/cli": "19.6.1",
@@ -4362,6 +4363,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-file": {
@@ -10856,6 +10866,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.0.tgz",
+      "integrity": "sha512-NyZ76wA4yElZWBHzSgEJc28a0u6QZvhb6w0azeL2k7+Q1gAzVK+IqQYXhVOC/mzi+HZIozrZvBVeSeOZNR2bqA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -11210,6 +11233,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "node-pg-migrate": "7.8.0",
     "pg": "8.13.1",
     "react": "19.0.0",
-    "react-dom": "19.0.0"
+    "react-dom": "19.0.0",
+    "swr": "^2.3.0"
   },
   "devDependencies": {
     "@commitlint/cli": "19.6.1",

--- a/pages/status/index.js
+++ b/pages/status/index.js
@@ -1,0 +1,58 @@
+import useSWR from "swr";
+
+async function fetchAPI(key) {
+  const response = await fetch(key);
+  const responseBody = await response.json();
+
+  return responseBody;
+}
+
+export default function StatusPage() {
+  return (
+    <>
+      <h1>Status Page</h1>
+      <UpdatedAt />
+      <DatabaseStatus />
+    </>
+  );
+}
+
+function UpdatedAt() {
+  const { data, error } = useSWR("/api/v1/status", fetchAPI, {
+    refreshInterval: 2000,
+  });
+
+  if (error) return <p>Error loading data</p>;
+  if (!data) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <p>Updated at: {new Date(data.updated_at).toLocaleString()}</p>
+    </div>
+  );
+}
+
+function DatabaseStatus() {
+  const { data, error } = useSWR("/api/v1/status", fetchAPI, {
+    refreshInterval: 2000,
+  });
+
+  if (error) return <p>Error loading data</p>;
+
+  return (
+    <div>
+      <h2>Database</h2>
+      {!data ? (
+        <p>Loading...</p>
+      ) : (
+        <>
+          <p>Version: {data.dependencies.database.version}</p>
+          <p>
+            Opened connections: {data.dependencies.database.opened_connections}
+          </p>
+          <p>Max connections: {data.dependencies.database.max_connections}</p>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces the SWR library for data fetching in the frontend and updates the `StatusPage` component to utilize this library. It also includes relevant updates to the `README.md` and `package.json` files.

### Integration of SWR library:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9): Added SWR to the list of technologies used in the project.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L34-R35): Added SWR as a dependency with version `^2.3.0`.

### Updates to `StatusPage` component:

* [`pages/status/index.js`](diffhunk://#diff-38358ee16d8173463f03c9a623e710c50cbf57fe7abd7ad2abab885755dcae94R1-R51): Implemented data fetching for the `StatusPage` component using SWR, including two new functions `UpdatedAt` and `DatabaseStatus` to display updated status information and database status respectively.