### PR TITLE
Implement model `migrator` and integrate with `/api/v1/migrations`

### DIFF
--- a/infra/database.js
+++ b/infra/database.js
@@ -3,6 +3,7 @@ import { ServiceError } from "./errors.js";
 
 async function query(queryObject) {
   let client;
+
   try {
     client = await getNewClient();
     const result = await client.query(queryObject);

--- a/models/migrator.js
+++ b/models/migrator.js
@@ -1,0 +1,52 @@
+import migrationRunner from "node-pg-migrate";
+import { join } from "node:path";
+import database from "infra/database.js";
+
+const defaultMigrationOptions = {
+  dryRun: true,
+  dir: join("infra", "migrations"),
+  direction: "up",
+  verbose: true,
+  migrationsTable: "pgmigrations",
+};
+
+async function listPendingMigrations() {
+  let dbClient;
+
+  try {
+    dbClient = await database.getNewClient();
+
+    const pendingMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dbClient,
+    });
+    return pendingMigrations;
+  } finally {
+    await dbClient?.end();
+  }
+}
+
+async function runPendingMigrations() {
+  let dbClient;
+
+  try {
+    dbClient = await database.getNewClient();
+
+    const migratedMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dbClient,
+      dryRun: false,
+    });
+
+    return migratedMigrations;
+  } finally {
+    await dbClient?.end();
+  }
+}
+
+const migrator = {
+  listPendingMigrations,
+  runPendingMigrations,
+};
+
+export default migrator;

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,8 +1,6 @@
 import { createRouter } from "next-connect";
-import migrationRunner from "node-pg-migrate";
-import { join } from "node:path";
-import database from "infra/database.js";
 import controller from "infra/controller.js";
+import migrator from "models/migrator.js";
 
 const router = createRouter();
 
@@ -11,48 +9,17 @@ router.post(postHandler);
 
 export default router.handler(controller.errorHandlers);
 
-const defaultMigrationOptions = {
-  dryRun: true,
-  dir: join("infra", "migrations"),
-  direction: "up",
-  verbose: true,
-  migrationsTable: "pgmigrations",
-};
-
 async function getHandler(request, response) {
-  let dbClient;
-
-  try {
-    dbClient = await database.getNewClient();
-
-    const pendingMigrations = await migrationRunner({
-      ...defaultMigrationOptions,
-      dbClient,
-    });
-    return response.status(200).json(pendingMigrations);
-  } finally {
-    await dbClient.end();
-  }
+  const pendingMigrations = await migrator.listPendingMigrations();
+  return response.status(200).json(pendingMigrations);
 }
 
 async function postHandler(request, response) {
-  let dbClient;
+  const migratedMigrations = await migrator.runPendingMigrations();
 
-  try {
-    dbClient = await database.getNewClient();
-
-    const migratedMigrations = await migrationRunner({
-      ...defaultMigrationOptions,
-      dbClient,
-      dryRun: false,
-    });
-
-    if (migratedMigrations.length > 0) {
-      return response.status(201).json(migratedMigrations);
-    }
-
-    return response.status(200).json(migratedMigrations);
-  } finally {
-    await dbClient.end();
+  if (migratedMigrations.length > 0) {
+    return response.status(201).json(migratedMigrations);
   }
+
+  return response.status(200).json(migratedMigrations);
 }


### PR DESCRIPTION
This pull request introduces a new migration system using the `node-pg-migrate` library and refactors the existing migration logic to improve code organization and maintainability. The most important changes include adding a new `migrator` module, updating the API to use this module, and cleaning up the database connection logic.

Migration system improvements:

* [`models/migrator.js`](diffhunk://#diff-675d499137a25966b668d68462918d2f2a81bc97e643002db2eaedf4920396d0R1-R52): Added a new `migrator` module with functions `listPendingMigrations` and `runPendingMigrations` to handle migration operations using `node-pg-migrate`.

API updates:

* [`pages/api/v1/migrations/index.js`](diffhunk://#diff-c140e431fa82defe6ecd0f6bea8f1e318394e6210718a42c7bbc5482af6519edL2-R3): Refactored the API to use the new `migrator` module instead of directly handling the migration logic. Removed redundant imports and database connection logic. [[1]](diffhunk://#diff-c140e431fa82defe6ecd0f6bea8f1e318394e6210718a42c7bbc5482af6519edL2-R3) [[2]](diffhunk://#diff-c140e431fa82defe6ecd0f6bea8f1e318394e6210718a42c7bbc5482af6519edL14-L57)

Database connection cleanup:

* [`infra/database.js`](diffhunk://#diff-bf1eedaaa7a752815cc90017f52c9f65596d66d05dc5cbd9dba6f8d248e6c986R6): Added an empty line for better code readability.